### PR TITLE
Feat: 이메일 인증 스케쥴러 기능

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2203,7 +2203,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -2527,6 +2526,15 @@
         "moment-timezone": "^0.5.x"
       }
     },
+    "cron-parser": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-3.5.0.tgz",
+      "integrity": "sha512-wyVZtbRs6qDfFd8ap457w3XVntdvqcwBGxBoTvJQH9KGVKL/fB+h2k3C8AqiVxvUQKN1Ps/Ns46CNViOpVDhfQ==",
+      "requires": {
+        "is-nan": "^1.3.2",
+        "luxon": "^1.26.0"
+      }
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -2593,7 +2601,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -3320,7 +3327,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -3464,8 +3470,7 @@
     "has-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -3825,6 +3830,15 @@
         "is-path-inside": "^3.0.1"
       }
     },
+    "is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
+    },
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -4040,6 +4054,11 @@
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
     },
+    "long-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
+      "integrity": "sha1-lyHXiLR+C8taJMLivuGg2lXatRQ="
+    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -4053,6 +4072,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
+      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -4448,6 +4472,16 @@
       "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
       "dev": true
     },
+    "node-schedule": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.0.0.tgz",
+      "integrity": "sha512-cHc9KEcfiuXxYDU+HjsBVo2FkWL1jRAUoczFoMIzRBpOA4p/NRHuuLs85AWOLgKsHtSPjN8csvwIxc2SqMv+CQ==",
+      "requires": {
+        "cron-parser": "^3.1.0",
+        "long-timeout": "0.1.1",
+        "sorted-array-functions": "^1.3.0"
+      }
+    },
     "nodemailer": {
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.3.tgz",
@@ -4593,8 +4627,7 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -5746,6 +5779,11 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
+    },
+    "sorted-array-functions": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
+      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA=="
     },
     "source-map": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,12 @@
         "express-session": "^1.17.2",
         "morgan": "^1.10.0",
         "multer": "^1.4.2",
+        "node-schedule": "^2.0.0",
         "nodemailer": "^6.6.3",
         "passport": "^0.4.1",
-        "pm2": "^5.1.0"
         "passport-google-oauth2": "^0.2.0",
-        "passport-local": "^1.0.0"
+        "passport-local": "^1.0.0",
+        "pm2": "^5.1.0"
     },
     "devDependencies": {
         "@babel/cli": "^7.14.5",

--- a/src/repositories/AuthRepository.js
+++ b/src/repositories/AuthRepository.js
@@ -45,13 +45,26 @@ export const updateAuth = async (data) =>{
 export const AuthGenerate = async (data)=>{
     try{
         const exAuth = await findByEmail(data.email)
-        console.log(exAuth);
         if(exAuth){
             return await updateAuth(data);
         }
         else{
             return await createAuth(data);
         }
+    }
+    catch(err){
+        console.error(err);
+        next(err);
+    }
+}
+
+export const deleteAuth = async (data) => {
+    try{
+        return await prisma.auth.delete({
+            where: {
+              email: data.email,
+            },
+          });
     }
     catch(err){
         console.error(err);

--- a/src/services/AuthServices.js
+++ b/src/services/AuthServices.js
@@ -129,6 +129,9 @@ export const EmailAuth = async (req,res,next) => {
                     auth: mail.RandomAuth
                 }
                 let response = await AuthRepository.AuthGenerate(data);
+                setTimeout(()=>{
+                    AuthRepository.deleteAuth(data);
+                }, 60000);
                 return res
                     .status(200)
                     .send(resFormat.successData(200,"인증번호 생성 성공",response));
@@ -156,18 +159,17 @@ export const AuthCheck = async (req, res, next) => {
             }
             return res
                 .status(403)
-                .send(resFormat.success(403, "인증번호가 일치하지 않음"));
+                .send(resFormat.fail(403, "인증번호가 일치하지 않음"));
 
         }
         return res
             .status(403)
-            .send(resFormat.success(403, "인증 테이블이 존재하지 않음"));
+            .send(resFormat.fail(403, "인증번호가 존재하지 않음"));
     } catch (err) {
         console.error(err);
         next(err);
     }
 };
-
 
 export const test = (req, res, next) => {
     return res.send("test");

--- a/src/services/AuthServices.js
+++ b/src/services/AuthServices.js
@@ -131,7 +131,7 @@ export const EmailAuth = async (req,res,next) => {
                 let response = await AuthRepository.AuthGenerate(data);
                 setTimeout(()=>{
                     AuthRepository.deleteAuth(data);
-                }, 60000);
+                }, 60000*3);
                 return res
                     .status(200)
                     .send(resFormat.successData(200,"인증번호 생성 성공",response));


### PR DESCRIPTION
## What :

### /repositories/AuthRepository.js 

function deleteAuth(data) -> Auth table data를 삭제하는 함수를 구현 
```
export const deleteAuth = async (data) => {
    try{
        return await prisma.auth.delete({
            where: {
              email: data.email,
            },
          });
    }
    catch(err){
        console.error(err);
        next(err);
    }
}
```
### /services/AuthServices.js 

기존 인증번호 생성 및 보내는 함수(EmailAuth)에 
setTimeout(deleteAuth, 3분) 함수를 넣어  3분 후 인증번호정보를 삭제하도록 함.

```
export const EmailAuth = async (req,res,next) => {
    try{
        mail.message.to=req.body.email;

        let transporter = nodemailer.createTransport(mail.mailConfig)
        let info = await transporter.sendMail(mail.message)
        
        console.log('Message sent: %s', info.messageId);

        if(info){
                const data = {
                    email: req.body.email,
                    auth: mail.RandomAuth
                }
                let response = await AuthRepository.AuthGenerate(data);
                setTimeout(()=>{
                    AuthRepository.deleteAuth(data);
                }, 60000*3);
                return res
                    .status(200)
                    .send(resFormat.successData(200,"인증번호 생성 성공",response));
            }
        else{
            return res
                .status(401)
                .json(resFormat.fail(401, "인증번호 보내기 실패"));
        }    
    }
    catch(err){
        console.error(err);
        next(err);
    }
}
```