### PR TITLE
Feat auth

### DIFF
--- a/src/controllers/AuthController.js
+++ b/src/controllers/AuthController.js
@@ -11,7 +11,12 @@ Router.post(
     AuthValidation.SignUpRequestValid,
     AuthServices.SingUp
 );
-Router.post("/login", AuthHandler.isNotLoggedIn, AuthServices.Login);
+Router.post(
+    "/login",
+    AuthHandler.isNotLoggedIn,
+    AuthValidation.LoginRequestValid,
+    AuthServices.Login
+);
 Router.get("/logout", AuthHandler.isLoggedIn, AuthServices.LogOut);
 Router.post(
     "/nicknamecheck",

--- a/src/controllers/AuthController.js
+++ b/src/controllers/AuthController.js
@@ -1,9 +1,16 @@
 import express from "express";
 import * as AuthServices from "../services/AuthServices";
 import * as AuthHandler from "../middlewares/AuthHandler";
+import * as AuthValidation from "../validations/AuthValidation";
+
 const Router = express.Router();
 
-Router.post("/signup", AuthHandler.isNotLoggedIn, AuthServices.SingUp);
+Router.post(
+    "/signup",
+    AuthHandler.isNotLoggedIn,
+    AuthValidation.SignUpRequestValid,
+    AuthServices.SingUp
+);
 Router.post("/login", AuthHandler.isNotLoggedIn, AuthServices.Login);
 Router.get("/logout", AuthHandler.isLoggedIn, AuthServices.LogOut);
 Router.post(
@@ -15,6 +22,5 @@ Router.post("/emailcheck", AuthHandler.isNotLoggedIn, AuthServices.EmailCheck);
 Router.get("/", AuthServices.GetUser);
 Router.post("/emailauth", AuthHandler.isNotLoggedIn, AuthServices.EmailAuth);
 Router.post("/authcheck", AuthHandler.isNotLoggedIn, AuthServices.AuthCheck);
-
 
 export default Router;

--- a/src/controllers/AuthController.js
+++ b/src/controllers/AuthController.js
@@ -20,12 +20,26 @@ Router.post(
 Router.get("/logout", AuthHandler.isLoggedIn, AuthServices.LogOut);
 Router.post(
     "/nicknamecheck",
-    AuthHandler.isNotLoggedIn,
+    AuthValidation.NicknameCheckRequestValid,
     AuthServices.NicknameCheck
 );
-Router.post("/emailcheck", AuthHandler.isNotLoggedIn, AuthServices.EmailCheck);
+Router.post(
+    "/emailcheck",
+    AuthValidation.EmailCheckRequestValid,
+    AuthServices.EmailCheck
+);
 Router.get("/", AuthServices.GetUser);
-Router.post("/emailauth", AuthHandler.isNotLoggedIn, AuthServices.EmailAuth);
-Router.post("/authcheck", AuthHandler.isNotLoggedIn, AuthServices.AuthCheck);
+Router.post(
+    "/emailauth",
+    AuthHandler.isNotLoggedIn,
+    AuthValidation.EmailCheckRequestValid,
+    AuthServices.EmailAuth
+);
+Router.post(
+    "/authcheck",
+    AuthHandler.isNotLoggedIn,
+    AuthValidation.MailAuthRequestValid,
+    AuthServices.AuthCheck
+);
 
 export default Router;

--- a/src/services/AuthServices.js
+++ b/src/services/AuthServices.js
@@ -31,7 +31,6 @@ export const SingUp = async (req, res, next) => {
             hashPassword
         );
         if (response) {
-            console.log("tester");
             passport.authenticate("local", (err, user, info) => {
                 if (!user) {
                     return res

--- a/src/validations/AuthValidation.js
+++ b/src/validations/AuthValidation.js
@@ -2,7 +2,21 @@ import { check } from "express-validator";
 import validationFunction from "./validationFunction";
 import resFormat from "../utils/resFormat";
 
+//email nicnname password
 export const SignUpRequestValid = async (req, res, next) => {
+    await check("nickname")
+        .trim()
+        .notEmpty()
+        .isString()
+        .withMessage("잘못된 형식입니다.")
+        .isLength({ max: 12 })
+        .withMessage("닉네임은 12자 이내로 작성해야 합니다.")
+        .run(req);
+    LoginRequestValid(req, res, next);
+};
+
+//email password
+export const LoginRequestValid = async (req, res, next) => {
     await check("email")
         .exists()
         .withMessage("email이 없습니다.")
@@ -13,14 +27,6 @@ export const SignUpRequestValid = async (req, res, next) => {
     await check("password")
         .matches(/^[a-zA-Z0-9가-힣]{8,}$/)
         .withMessage("비밀번호 형식에 맞지 않습니다.")
-        .run(req);
-    await check("nickname")
-        .trim()
-        .notEmpty()
-        .isString()
-        .withMessage("잘못된 형식입니다.")
-        .isLength({ max: 12 })
-        .withMessage("닉네임은 12자 이내로 작성해야 합니다.")
         .run(req);
     validationFunction(req, res, next);
 };

--- a/src/validations/AuthValidation.js
+++ b/src/validations/AuthValidation.js
@@ -30,3 +30,37 @@ export const LoginRequestValid = async (req, res, next) => {
         .run(req);
     validationFunction(req, res, next);
 };
+
+export const NicknameCheckRequestValid = async (req, res, next) => {
+    await check("nickname")
+        .trim()
+        .notEmpty()
+        .isString()
+        .withMessage("잘못된 형식입니다.")
+        .isLength({ max: 12 })
+        .withMessage("닉네임은 12자 이내로 작성해야 합니다.")
+        .run(req);
+    validationFunction(req, res, next);
+};
+
+export const EmailCheckRequestValid = async (req, res, next) => {
+    await check("email")
+        .exists()
+        .withMessage("email이 없습니다.")
+        .bail()
+        .isEmail()
+        .withMessage("형식에 맞지 않습니다.")
+        .run(req);
+    validationFunction(req, res, next);
+};
+
+export const MailAuthRequestValid = async (req, res, next) => {
+    await check("auth")
+        .exists()
+        .withMessage("필요값이 없습니다.")
+        .bail()
+        .notEmpty()
+        .withMessage("공백허용하지 않습니다.")
+        .run(req);
+    EmailCheckRequestValid(req, res, next);
+};

--- a/src/validations/AuthValidation.js
+++ b/src/validations/AuthValidation.js
@@ -1,0 +1,26 @@
+import { check } from "express-validator";
+import validationFunction from "./validationFunction";
+import resFormat from "../utils/resFormat";
+
+export const SignUpRequestValid = async (req, res, next) => {
+    await check("email")
+        .exists()
+        .withMessage("email이 없습니다.")
+        .bail()
+        .isEmail()
+        .withMessage("형식에 맞지 않습니다.")
+        .run(req);
+    await check("password")
+        .matches(/^[a-zA-Z0-9가-힣]{8,}$/)
+        .withMessage("비밀번호 형식에 맞지 않습니다.")
+        .run(req);
+    await check("nickname")
+        .trim()
+        .notEmpty()
+        .isString()
+        .withMessage("잘못된 형식입니다.")
+        .isLength({ max: 12 })
+        .withMessage("닉네임은 12자 이내로 작성해야 합니다.")
+        .run(req);
+    validationFunction(req, res, next);
+};


### PR DESCRIPTION
## /api/Auth 관련 한 validation 코드 추가

```js
//email nicnname password
export const SignUpRequestValid = async (req, res, next) => {
    await check("nickname")
        .trim()
        .notEmpty()
        .isString()
        .withMessage("잘못된 형식입니다.")
        .isLength({ max: 12 })
        .withMessage("닉네임은 12자 이내로 작성해야 합니다.")
        .run(req);
    LoginRequestValid(req, res, next);
};

//email password
export const LoginRequestValid = async (req, res, next) => {
    await check("email")
        .exists()
        .withMessage("email이 없습니다.")
        .bail()
        .isEmail()
        .withMessage("형식에 맞지 않습니다.")
        .run(req);
    await check("password")
        .matches(/^[a-zA-Z0-9가-힣]{8,}$/)
        .withMessage("비밀번호 형식에 맞지 않습니다.")
        .run(req);
    validationFunction(req, res, next);
};
```
위처럼 재사용 할 수있는부분은 재사용 했는데 이부분에 대해서 괜찮으면 merge하고 분리시키자고 하면 수정하겠음