### PR TITLE
fix: 프로필 조회버그 수정

### DIFF
--- a/src/services/ProfileServices.js
+++ b/src/services/ProfileServices.js
@@ -49,14 +49,19 @@ export const CreateProfile = async (req, res, next) => {
 
 export const GetUserProfile = async (req, res, next) => {
     try {
+        const exProfile = await ProfileRepository.fineByUserId(
+            parseInt(req.params.userId, 10)
+        );
+        if (!exProfile[0]) {
+            return res
+                .status(403)
+                .send(
+                    resFormat.fail(403, "유저의 프로필이 존재하지 않습니다.")
+                );
+        }
         const UserProfile = await UserRepository.findByIdWithProfile(
             parseInt(req.params.userId, 10)
         );
-        if (!UserProfile) {
-            return res
-                .status(403)
-                .send(resFormat.fail(403, "유저의 프로필이 존재하지 않습니다"));
-        }
         return res
             .status(200)
             .send(resFormat.successData(200, "프로필 조회 성공", UserProfile));


### PR DESCRIPTION
### 기존
- user레포지토리 코드에서 찾은걸로 res 응답을 프로필이 없다는 응답을 보냄. 유저가 있고 프로필이 없는 경우도 성공인채로 보내짐.

### 수정
- profile 레포지토리에서 userId로 찾고 없으면 프로필이 없다고 보냄, 프로필과 user는 1:1이라 프로필이 있는데 유저가 없는 경우는 없으니 검사 1번이면 추후 검사 불필요