### PR TITLE
fix : email 인증 AUTH

### DIFF
--- a/src/repositories/AuthRepository.js
+++ b/src/repositories/AuthRepository.js
@@ -62,11 +62,17 @@ export const AuthGenerate = async (data) => {
 
 export const deleteAuth = async (data) => {
     try {
-        return await prisma.auth.delete({
+        return await prisma.auth.deleteMany({
             where: {
-                email: data.email,
-                auth: data.auth
-            },
+                AND : [
+                    {
+                        email : data.email,
+                    },
+                    {
+                        auth : data.auth,
+                    }
+            ],
+        },
         });
     } catch (err) {
         console.error(err);


### PR DESCRIPTION
### Email Auth Delete Isuue

```javascript
return await prisma.auth.delete({
            where: {
                email: data.email,
                auth : data.auth
        },
});

return await prisma.auth.deleteMany({
            where: {
                AND : [
                    {
                        email : data.email,
                    },
                    {
                        auth : data.auth,
                    }
            ],
        },
 });
```
> 기존 코드는 delete 를 이용했는데 delete의 경우 where에는 한가지 조건밖에 설정이 되지않는다. AND 나 OR 연산을 수행하기 위해서는 deleteMany를 사용해주어야 함.