### PR TITLE
fix : 유저의 오픈 참여 채널 리스트 정보 주기

### DIFF
--- a/src/repositories/ChannelRepository.js
+++ b/src/repositories/ChannelRepository.js
@@ -86,51 +86,6 @@ export const findById = async (id) => {
     }
 };
 
-export const findManyByUserid = async (id) => {
-    try {
-        return await prisma.channel.findMany({
-            where: {
-                adminId: id,
-            },
-            include: {
-                admin: {
-                    select: {
-                        id: true,
-                        email: true,
-                        nickname : true,
-                    },
-                },
-                participants: {
-                    select: {
-                        userId: true,
-                    },
-                },
-                category: {
-                    include: {
-                        category: true,
-                    },
-                },
-                tags: {
-                    include: {
-                        tag: true,
-                    },
-                },
-                channellike: {
-                    select: {
-                        userId: true,
-                    },
-                },
-                channelImage: {
-                    select: {
-                        src: true,
-                    }
-                }
-            },
-        });
-    } catch (err) {
-        console.error(err);
-    }
-};
 
 export const updateChannel = async (data) => {
     try {

--- a/src/services/ChannelServices.js
+++ b/src/services/ChannelServices.js
@@ -48,7 +48,7 @@ export const GetChannelList = async (req, res, next) => {
             return res.status(500).send(resFormat.fail(500, "알수없는 에러"));
         } else {
             return res.status(200).send(
-                resFormat.successData(200, "내 채널 정보", {
+                resFormat.successData(200, "채널 정보 리스트", {
                     adminChannl: adminChannel,
                     participantChannel: ParticipantChannel,
                 })

--- a/src/services/ChannelServices.js
+++ b/src/services/ChannelServices.js
@@ -35,17 +35,25 @@ export const CreateChannel = async (req, res, next) => {
 
 export const GetChannelList = async (req, res, next) => {
     try {
-        const data = await ChannelRepository.findManyByUserid(
-            parseInt(req.params.userId, 10)
+        const adminChannel = await ChannelRepository.findAdminChannel(
+            req.params.id,
+            SelectOption
         );
-        if (!data) {
-            return res
-                .status(403)
-                .send(resFormat.fail(403, "채널이 존재 하지 않습니다."));
+        const ParticipantChannel = await ChannelRepository.findParticipantChannel(
+            req.params.id,
+            SelectOption
+        );
+
+        if (!ParticipantChannel) {
+            return res.status(500).send(resFormat.fail(500, "알수없는 에러"));
+        } else {
+            return res.status(200).send(
+                resFormat.successData(200, "내 채널 정보", {
+                    adminChannl: adminChannel,
+                    participantChannel: ParticipantChannel,
+                })
+            );
         }
-        return res
-            .status(200)
-            .send(resFormat.successData(200, "채널 목록 가져오기 성공", data));
     } catch (err) {
         console.error(err);
         next(err);
@@ -55,8 +63,7 @@ export const GetChannelList = async (req, res, next) => {
 export const GetChannelInfo = async (req, res, nex) => {
     try {
         const data = await ChannelRepository.findById(
-            parseInt(req.params.channelId),
-            10
+            parseInt(req.params.channelId,10)
         );
         if (!data) {
             return res


### PR DESCRIPTION
### 특정유저의 오픈, 참여 채널 리스트 정보 주기 api 변경

##### 기존에 존재하던 아래의 라우터의 경우, 오픈 채널의 대한 정보만 주었기 때문에, 참여 채널 정보도 줄 수 있게 코드를 수정함.

#### ChannelController
```javascript
Router.get(
    "/:userId",
    ChannelValidation.GetListRequestValid,
    ChannelServices.GetChannelList
);
```

#### ChannelServices
```javascript
export const GetChannelList = async (req, res, next) => {
    try {
        const adminChannel = await ChannelRepository.findAdminChannel(
            req.params.id,
            SelectOption
        );
        const ParticipantChannel = await ChannelRepository.findParticipantChannel(
            req.params.id,
            SelectOption
        );

        if (!ParticipantChannel) {
            return res.status(500).send(resFormat.fail(500, "알수없는 에러"));
        } else {
            return res.status(200).send(
                resFormat.successData(200, "채널 리스트 정보", {
                    adminChannl: adminChannel,
                    participantChannel: ParticipantChannel,
                })
            );
        }
    } catch (err) {
        console.error(err);
        next(err);
    }
};
```
- 기존에 존재하던 `ChannelRepository.findAdminChannel` 과 `ChannelRepository.findParticipantChannel`를 재사용함. req.params.userId 정보를 이용하여 정보를 받음
- 필요가 없어진 ChannelRespository.findManyUserid 삭제