### PR TITLE
fix: channel 요청에서의 tag에서 tags로 변경

### DIFF
--- a/src/services/ChannelServices.js
+++ b/src/services/ChannelServices.js
@@ -342,7 +342,7 @@ const CreateOption = (bodydata) => {
         name: bodydata.name,
         introduce: bodydata.introduce,
         tags: {
-            create: ChangeObject(bodydata.tag),
+            create: ChangeObject(bodydata.tags),
         },
         category: {
             create: {
@@ -375,9 +375,9 @@ const UpdateOption = (bodydata) => {
     if (bodydata.introduce) {
         Option.introduce = bodydata.introduce;
     }
-    if (bodydata.tag) {
+    if (bodydata.tags) {
         Option.tags = {
-            create: ChangeObject(bodydata.tag),
+            create: ChangeObject(bodydata.tags),
         };
     }
     if (bodydata.category) {
@@ -393,7 +393,7 @@ const UpdateOption = (bodydata) => {
             },
         };
     }
-    if (bodydata.channelImage) {
+    if (bodydata.src) {
         Option.channelImage = {
             update: {
                 src: bodydata.src,

--- a/src/validations/ChannelValidation.js
+++ b/src/validations/ChannelValidation.js
@@ -38,9 +38,9 @@ export const CreateRequestValid = async (req, res, next) => {
         .isString()
         .withMessage("category는 String 형식에 맞게 들어와야 합니다.")
         .run(req);        
-    await check("tag")
+    await check("tags")
         .exists()
-        .withMessage("tag가 존재하지 않습니다.")
+        .withMessage("tags가 존재하지 않습니다.")
         .if((value, { req }) => value !== null)
         .isArray()
         .withMessage("배열만 가능합니다.")
@@ -50,8 +50,8 @@ export const CreateRequestValid = async (req, res, next) => {
         .withMessage("src가 존재하지 않습니다.")
         .run(req);
 
-    if (!(req.body.tag === null)) {
-        await check("tag.*")
+    if (!(req.body.tags === null)) {
+        await check("tags.*")
             .trim()
             .notEmpty()
             .withMessage("값이 없습니다.")


### PR DESCRIPTION
### api 요청 변수 조정

table에서는 tags로 정의 되어있고, api 요청에선 tag로 주기 때문에 로직 상 헷갈린다는 요청을 받아 수정함. 
tag로 받던 api 요청을 tags로 명시하여 통일성을 줌.

### router
```javascript
Router.post(
    "/",
    AuthHandler.isLoggedIn,
    ChannelValidation.CreateRequestValid,
    ChannelServices.CreateChannel
);

Router.patch(
    "/",
    AuthHandler.isLoggedIn,
    ChannelValidation.UpdateRequestValid,
    ChannelServices.UpdateChannel
);
```

##### json
```json
{
    "userId" : 1,
    "name" : "채널의 이름2",
    "introduce" : "channel의 소개",
    "tags" : ["tag1","tag2","tag3"],
    "category" : "category",
    "src" : "https://storage.googleapis.com/jandy_bucket/cssicon_1629673024534.png"
}
```