### PR TITLE
feat: post의 status 상태값 완료 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -306,4 +306,5 @@ enum Status {
   Open
   Reservation
   Close
+  Clear
 }

--- a/src/repositories/PostRepository.js
+++ b/src/repositories/PostRepository.js
@@ -127,6 +127,11 @@ export const findPostByChannelId = async (channelId) => {
         return await prisma.post.findMany({
             where: {
                 channelId,
+                NOT :[
+                    {
+                        status : 'Clear'
+                    }
+                ]
             },
             orderBy: [
                 {


### PR DESCRIPTION
### post의 status 상태 값 완료 추가

> 아카이빙 작성 이전에 게시글의 상태가 필요하여 `Clear`(완료) 상태를 추가하였습니다.

##### DB schema 변경

```javascript
enum Status {
  Notice // 공지
  Open // 열림
  Reservation // 예약
  Close // 안열림
  Clear // 완료
}
```
##### Repository (옵션값 변경)
- 해당하는 채널의 게시글 리스트를 가져옴
- NOT 옵션을 이용하여 status가 `Clear`인 data는 가져오지 않음.
```javascript
export const findPostByChannelId = async (channelId) => {
    try {
        return await prisma.post.findMany({
            where: {
                channelId,
                NOT :[
                    {
                        status : 'Clear'
                    }
                ]
            },
        ......
    } catch (err) {
        console.error(err);
    }
};
```