### PR TITLE
fix: channel Profile의 참가자, 관리자의 재능 정보 추가

### DIFF
--- a/src/repositories/ChannelRepository.js
+++ b/src/repositories/ChannelRepository.js
@@ -30,6 +30,16 @@ export const findById = async (id) => {
                                         src: true,
                                     },
                                 },
+                                wellTalent: {
+                                    select: {
+                                        contents: true,
+                                    },
+                                },
+                                interestTalent: {
+                                    select: {
+                                        contents: true,
+                                    },
+                                },
                             }
                         }
                     },
@@ -46,6 +56,16 @@ export const findById = async (id) => {
                                         profileImage: {
                                             select: {
                                                 src: true,
+                                            },
+                                        },
+                                        wellTalent: {
+                                            select: {
+                                                contents: true,
+                                            },
+                                        },
+                                        interestTalent: {
+                                            select: {
+                                                contents: true,
                                             },
                                         },
                                     }


### PR DESCRIPTION
## channel Profile의 참가자, 관리자의 재능 정보 추가

> /api/Channel/:userId 의 api 정보중에서 관리자와 참여자의 재능정보가 누락되어있어 추가시킴


