### PR TITLE
AWS migration에서 Dockerfile 픽스 필요

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16
 
-WORKDIR /src/index
+WORKDIR /usr/app
 
 COPY package*.json ./
 

--- a/server.update.sh
+++ b/server.update.sh
@@ -4,18 +4,11 @@ git pull
 cd ..
 
 cd Jandy_Web_Front
-:<<'END'
-git fetch origin
-git pull
-yarn install
-yarn build
-END
 rm -rf front_build
 cp -r build front_build
 rm -rf ../Jandy_Web_Back/front_build
 mv ./front_build ../Jandy_Web_Back
 cd ..
-
 
 cd Jandy_Web_Back
 docker stop upgle

--- a/server.update.sh
+++ b/server.update.sh
@@ -1,17 +1,21 @@
 cd Jandy_Web_Back
-git fetch origin 
-git checkout -t origin/dev dev
-git reset --hard HEAD
+git fetch origin
 git pull
 cd ..
 
 cd Jandy_Web_Front
+:<<'END'
 git fetch origin
-git checkout -t origin/main main
-git reset --hard HEAD
 git pull
+yarn install
 yarn build
+END
+rm -rf front_build
+cp -r build front_build
+rm -rf ../Jandy_Web_Back/front_build
+mv ./front_build ../Jandy_Web_Back
 cd ..
+
 
 cd Jandy_Web_Back
 docker stop upgle
@@ -20,3 +24,4 @@ docker rmi upgle
 
 docker build -t upgle .
 docker run -d -p 4000:4000 --name upgle upgle
+

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ app.use(ErrorHandler.errorHandler);
 if (process.env.NODE_ENV === "production") {
     const buildDirectory = path.resolve(
         __dirname,
-        "../../Jandy_Web_Front/build"
+        "../front_build"
     );
     console.log(buildDirectory);
     app.use(express.static(buildDirectory));


### PR DESCRIPTION
# 개발사항

-  도커파일 소스코드 복사 로직 <-> 쉘 스크립트 파일 변경
-  `src/index.js`의 프론트 빌드 파일 경로 변경

## 세부사항

### 쉘 스크립트 파일 변경 및 경로 변경

-  도커파일은 빌드할때 현재 도커파일이 있는 디렉토리의 상위 디렉토리로 가지 못합니다. 따라서 #63 을 해결하기 위해 도커파일 내에서 소스코드 복사기능을 상위 디렉토리에 있는 것을 대상으로 할 수 없었습니다. 차선책으로 쉘스크립트 파일에서 프론트 빌드파일의 복사본을 front_build로 이름지어서 카피해 옮기고 도커파일은 수정하지 않음. 이름은 왜 프론트 빌드로 지었냐면 서버 레포 루트에 서버 빌드 폴더도 같이있어서, 이름을 다르게 지었습니다. `src/index.js`의 프론트 빌드 파일 경로도 맞춰서 수정해주었음.

## 추가사항

#### SSL 인증서 적용
서버 인스턴스에 nginx 설정하고, nginx를 통하여 인증서 적용 및 http-https 리다이렉트 적용하였습니다. 도메인도 인서가 ip 등록 다시 해줘서 이제 도메인으로 접속가능함. 상세는 오늘 회의나 다음주 미팅에서 디비 마이그레이션에서 설명하겠습니다.

