### PR TITLE
Archive 조회 API 

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -293,9 +293,9 @@ model Comment {
   author    User      @relation("comment", fields: [authorId], references: [id])
   authorId  Int
   post      Post?      @relation(fields: [postId], references: [id])
-  postId    Int
+  postId    Int?
   archive   Archive? @relation(fields: [archiveId], references: [id])
-  archiveId Int
+  archiveId Int?
   createdAt DateTime
   updatedAt DateTime?
 

--- a/src/controllers/ArchiveController.js
+++ b/src/controllers/ArchiveController.js
@@ -9,26 +9,42 @@ Router.post(
     "/",
     AuthHandler.isLoggedIn,
     ArchiveValidation.CreateRequestValid,
-    ArchiveServices.CreateArchive,
+    ArchiveServices.CreateArchive
 );
 
 Router.delete(
     "/:archiveId",
     AuthHandler.isLoggedIn,
     ArchiveValidation.DeleteRequestValid,
-    ArchiveServices.DeleteArchive,
+    ArchiveServices.DeleteArchive
 );
 
 Router.patch(
     "/:archiveId",
     AuthHandler.isLoggedIn,
     ArchiveValidation.UpdateRequestValid,
-    ArchiveServices.UpdateArchive,
+    ArchiveServices.UpdateArchive
 );
 
-// Test용 조회
 Router.get(
     "/:archiveId",
-    ArchiveServices.GetArchive,
+    AuthHandler.isLoggedIn,
+    ArchiveValidation.GetRequestValid,
+    ArchiveServices.GetArchive
 );
+
+Router.get(
+    "/channel/:channelId",
+    AuthHandler.isLoggedIn,
+    ArchiveValidation.GetByChannelRequestValid,
+    ArchiveServices.GetChannelArchiveList
+);
+
+Router.get(
+    "/profile/:userId",
+    AuthHandler.isLoggedIn,
+    ArchiveValidation.GetByUserRequestValid,
+    ArchiveServices.GetUserArchiveList
+);
+
 export default Router;

--- a/src/controllers/CommentContoller.js
+++ b/src/controllers/CommentContoller.js
@@ -25,8 +25,18 @@ Router.delete(
     CommentServices.DeleteComment
 );
 
-Router.get("/", AuthHandler.isLoggedIn, CommentServices.GetCommentList);
+Router.get(
+    "/",
+    AuthHandler.isLoggedIn,
+    CommentValidation.GetListRequestValid,
+    CommentServices.GetCommentList
+);
 
-Router.get("/:commentId", AuthHandler.isLoggedIn, CommentServices.GetComment);
+Router.get(
+    "/:commentId",
+    AuthHandler.isLoggedIn,
+    CommentValidation.GetRequestValid,
+    CommentServices.GetComment
+);
 
 export default Router;

--- a/src/controllers/CommentContoller.js
+++ b/src/controllers/CommentContoller.js
@@ -4,7 +4,6 @@ import * as CommentValidation from "../validations/CommentValidation";
 import * as CommentServices from "../services/CommentServices";
 const Router = express.Router();
 
-
 Router.post(
     "/",
     AuthHandler.isLoggedIn,
@@ -25,5 +24,9 @@ Router.delete(
     CommentValidation.DeleteRequestValid,
     CommentServices.DeleteComment
 );
+
+Router.get("/", AuthHandler.isLoggedIn, CommentServices.GetCommentList);
+
+Router.get("/:commentId", AuthHandler.isLoggedIn, CommentServices.GetComment);
 
 export default Router;

--- a/src/controllers/PostController.js
+++ b/src/controllers/PostController.js
@@ -54,5 +54,4 @@ Router.post(
     PostServices.NotAttention
 );
 
-
 export default Router;

--- a/src/repositories/ArchiveRepository.js
+++ b/src/repositories/ArchiveRepository.js
@@ -2,14 +2,13 @@ import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
-export const createArchive = async(data) => {
+export const createArchive = async (data) => {
     try {
-        return prisma.archive.create({data});
-    }
-    catch (err) {
+        return prisma.archive.create({ data });
+    } catch (err) {
         console.error(err);
     }
-}
+};
 
 export const deleteArchive = async (id) => {
     try {
@@ -21,11 +20,11 @@ export const deleteArchive = async (id) => {
     }
 };
 
-export const updateArchive = async (id,data) => {
+export const updateArchive = async (id, data) => {
     try {
         await prisma.archive.update({
             where: {
-                id : id
+                id: id,
             },
             data: {
                 images: {
@@ -44,10 +43,11 @@ export const updateArchive = async (id,data) => {
         console.error(err);
     }
 };
+
 export const findById = async (id) => {
     try {
         return prisma.archive.findUnique({
-            where : {id},
+            where: { id },
             include: {
                 owner: {
                     select: {
@@ -65,7 +65,7 @@ export const findById = async (id) => {
                         },
                     },
                 },
-                post : {
+                post: {
                     select: {
                         title: true,
                         content: true,
@@ -87,52 +87,6 @@ export const findById = async (id) => {
                                 },
                             },
                         },
-                        comment: {
-                            select: {
-                                author: {
-                                    select: {
-                                        id: true,
-                                        email: true,
-                                        nickname: true,
-                                        profile: {
-                                            select: {
-                                                profileImage: {
-                                                    select: {
-                                                        src: true,
-                                                    },
-                                                },
-                                            },
-                                        },
-                                    },
-                                },
-                                content: true,
-                                createdAt: true,
-                                updatedAt: true,
-                            },
-                        },
-                    }
-                },
-                archiveComment: {
-                    select: {
-                        author: {
-                            select: {
-                                id: true,
-                                email: true,
-                                nickname: true,
-                                profile: {
-                                    select: {
-                                        profileImage: {
-                                            select: {
-                                                src: true,
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                        content: true,
-                        createdAt: true,
-                        updatedAt: true,
                     },
                 },
                 images: {
@@ -142,8 +96,7 @@ export const findById = async (id) => {
                 },
             },
         });
-    }
-    catch (err) {
+    } catch (err) {
         console.error(err);
     }
-}
+};

--- a/src/repositories/ArchiveRepository.js
+++ b/src/repositories/ArchiveRepository.js
@@ -44,10 +44,148 @@ export const updateArchive = async (id, data) => {
     }
 };
 
-export const findById = async (id) => {
+export const getArchiveById = async (id) => {
     try {
         return prisma.archive.findUnique({
             where: { id },
+            include: {
+                owner: {
+                    select: {
+                        id: true,
+                        email: true,
+                        nickname: true,
+                        profile: {
+                            select: {
+                                profileImage: {
+                                    select: {
+                                        src: true,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                post: {
+                    select: {
+                        title: true,
+                        content: true,
+                        createdAt: true,
+                        updatedAt: true,
+                        author: {
+                            select: {
+                                id: true,
+                                email: true,
+                                nickname: true,
+                                profile: {
+                                    select: {
+                                        profileImage: {
+                                            select: {
+                                                src: true,
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                images: {
+                    select: {
+                        src: true,
+                    },
+                },
+            },
+        });
+    } catch (err) {
+        console.error(err);
+    }
+};
+
+export const getArchiveListByChannelId = async (channelId, isPublic) => {
+    const status = isPublic ? "Public" : undefined;
+    try {
+        return prisma.archive.findMany({
+            where: {
+                channelId,
+                status,
+            },
+            orderBy: [
+                {
+                    createdAt: "desc",
+                },
+                {
+                    updatedAt: "desc",
+                },
+            ],
+            include: {
+                owner: {
+                    select: {
+                        id: true,
+                        email: true,
+                        nickname: true,
+                        profile: {
+                            select: {
+                                profileImage: {
+                                    select: {
+                                        src: true,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                post: {
+                    select: {
+                        title: true,
+                        content: true,
+                        createdAt: true,
+                        updatedAt: true,
+                        author: {
+                            select: {
+                                id: true,
+                                email: true,
+                                nickname: true,
+                                profile: {
+                                    select: {
+                                        profileImage: {
+                                            select: {
+                                                src: true,
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                images: {
+                    select: {
+                        src: true,
+                    },
+                },
+            },
+        });
+    } catch (err) {
+        console.error(err);
+    }
+};
+
+export const getArchiveListByUserId = async (userId, isPublic) => {
+    try {
+        const status = isPublic ? "Public" : undefined;
+        return prisma.archive.findMany({
+            where: {
+                ownerId: userId,
+                status,
+            },
+            orderBy: [
+                {
+                    createdAt: "desc",
+                },
+                {
+                    updatedAt: "desc",
+                },
+            ],
             include: {
                 owner: {
                     select: {

--- a/src/repositories/CommentRepository.js
+++ b/src/repositories/CommentRepository.js
@@ -52,6 +52,24 @@ export const getCommentById = async (id) => {
     try {
         return await prisma.comment.findUnique({
             where: { id },
+            include: {
+                author: {
+                    select: {
+                        id: true,
+                        email: true,
+                        nickname: true,
+                        profile: {
+                            select: {
+                                profileImage: {
+                                    select: {
+                                        src: true,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
         });
     } catch (err) {
         console.error(err);
@@ -74,6 +92,24 @@ export const getCommentByTypeId = async (type, id) => {
                     updatedAt: "desc",
                 },
             ],
+            include: {
+                author: {
+                    select: {
+                        id: true,
+                        email: true,
+                        nickname: true,
+                        profile: {
+                            select: {
+                                profileImage: {
+                                    select: {
+                                        src: true,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
         });
     } catch (err) {
         console.error(err);

--- a/src/repositories/CommentRepository.js
+++ b/src/repositories/CommentRepository.js
@@ -47,3 +47,35 @@ export const checkMyComment = async (id, authorId) => {
         console.error(err);
     }
 };
+
+export const getCommentById = async (id) => {
+    try {
+        return await prisma.comment.findUnique({
+            where: { id },
+        });
+    } catch (err) {
+        console.error(err);
+    }
+};
+
+export const getCommentByTypeId = async (type, id) => {
+    try {
+        const typeName = type == "post" ? "postId" : "archiveId";
+        const whereQuery = {};
+        whereQuery[typeName] = id;
+        console.log(whereQuery);
+        return await prisma.comment.findMany({
+            where: whereQuery,
+            orderBy: [
+                {
+                    createdAt: "desc",
+                },
+                {
+                    updatedAt: "desc",
+                },
+            ],
+        });
+    } catch (err) {
+        console.error(err);
+    }
+};

--- a/src/repositories/PostRepository.js
+++ b/src/repositories/PostRepository.js
@@ -24,29 +24,6 @@ export const findById = async (id) => {
                         },
                     },
                 },
-                comment: {
-                    select: {
-                        author: {
-                            select: {
-                                id: true,
-                                email: true,
-                                nickname: true,
-                                profile: {
-                                    select: {
-                                        profileImage: {
-                                            select: {
-                                                src: true,
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                        content: true,
-                        createdAt: true,
-                        updatedAt: true,
-                    },
-                },
                 attention: {
                     select: {
                         user: {
@@ -83,11 +60,11 @@ export const createPost = async (data) => {
     }
 };
 
-export const updatePost = async (id,data) => {
+export const updatePost = async (id, data) => {
     try {
         await prisma.post.update({
             where: {
-                id : id
+                id: id,
             },
             data: {
                 images: {

--- a/src/services/ArchiveServices.js
+++ b/src/services/ArchiveServices.js
@@ -21,7 +21,7 @@ export const CreateArchive = async (req, res, next) => {
                     )
                 );
         }
-        if(req.body.postId){
+        if (req.body.postId) {
             const checkPostCleared = await PostRepository.checkPostCleared(
                 parseInt(req.body.postId, 10)
             );
@@ -31,7 +31,7 @@ export const CreateArchive = async (req, res, next) => {
                     .send(resFormat.fail(401, "종료된 채팅방이 아닙니다."));
             }
         }
-        
+
         const response = await ArchiveRepository.createArchive(
             CreateOption(
                 req.user.id,
@@ -44,7 +44,10 @@ export const CreateArchive = async (req, res, next) => {
             return res
                 .status(500)
                 .send(
-                    resFormat.fail(500, "알수 없는 에러로 아카이브 작성하기 실패")
+                    resFormat.fail(
+                        500,
+                        "알수 없는 에러로 아카이브 작성하기 실패"
+                    )
                 );
         }
         return res
@@ -60,7 +63,7 @@ export const DeleteArchive = async (req, res, next) => {
     try {
         const checkOwner = await UserRepository.CheckMyArchive(
             req.user.id,
-            parseInt(req.params.archiveId,10),
+            parseInt(req.params.archiveId, 10)
         );
         if (!checkOwner[0]) {
             return res
@@ -68,14 +71,16 @@ export const DeleteArchive = async (req, res, next) => {
                 .send(resFormat.fail(401, "아카이빙 삭제 권한이 없습니다."));
         }
         const response = await ArchiveRepository.deleteArchive(
-            parseInt(req.params.archiveId,10),
+            parseInt(req.params.archiveId, 10)
         );
         if (!response) {
             return res
                 .status(500)
                 .send(resFormat.fail(500, "알수 없는 에러로 삭제 실패"));
         }
-        return res.status(200).send(resFormat.success(200, "아카이브 삭제 성공"));
+        return res
+            .status(200)
+            .send(resFormat.success(200, "아카이브 삭제 성공"));
     } catch (err) {
         console.error(err);
         next(err);
@@ -86,7 +91,7 @@ export const UpdateArchive = async (req, res, next) => {
     try {
         const checkOwner = await UserRepository.CheckMyArchive(
             req.user.id,
-            parseInt(req.params.archiveId,10),
+            parseInt(req.params.archiveId, 10)
         );
         if (!checkOwner[0]) {
             return res
@@ -94,7 +99,7 @@ export const UpdateArchive = async (req, res, next) => {
                 .send(resFormat.fail(401, "아카이브 수정 권한이 없습니다."));
         }
         const response = await ArchiveRepository.updateArchive(
-            parseInt(req.params.archiveId,10),
+            parseInt(req.params.archiveId, 10),
             UpdateOption(req.body)
         );
         if (!response) {
@@ -110,17 +115,72 @@ export const UpdateArchive = async (req, res, next) => {
         next(err);
     }
 };
+
 export const GetArchive = async (req, res, next) => {
     try {
-        const response = await ArchiveRepository.findById(
-            parseInt(req.params.archiveId,10),
+        const response = await ArchiveRepository.getArchiveById(
+            parseInt(req.params.archiveId, 10)
         );
         if (!response) {
             return res
                 .status(500)
                 .send(resFormat.fail(500, "알수 없는 에러로 정보 얻기 실패"));
         }
-        return res.status(200).send(resFormat.successData(200, "정보 얻기 성공" , response));
+        return res
+            .status(200)
+            .send(resFormat.successData(200, "정보 얻기 성공", response));
+    } catch (err) {
+        console.error(err);
+        next(err);
+    }
+};
+
+export const GetChannelArchiveList = async (req, res, next) => {
+    try {
+        const joinUser = await UserRepository.CheckJoinChannel(
+            req.user.id,
+            parseInt(req.params.channelId, 10)
+        );
+        let isPublic = true;
+        if (joinUser[0]) {
+            isPublic = false;
+        }
+        const response = await ArchiveRepository.getArchiveListByChannelId(
+            parseInt(req.params.channelId, 10),
+            isPublic
+        );
+        if (!response) {
+            return res
+                .status(500)
+                .send(resFormat.fail(500, "알수 없는 에러로 정보 얻기 실패"));
+        }
+        return res
+            .status(200)
+            .send(resFormat.successData(200, "정보 얻기 성공", response));
+    } catch (err) {
+        console.error(err);
+        next(err);
+    }
+};
+
+export const GetUserArchiveList = async (req, res, next) => {
+    try {
+        let isPublic = true;
+        if (parseInt(req.params.userId, 10) === req.user.id) {
+            isPublic = false;
+        }
+        const response = await ArchiveRepository.getArchiveListByUserId(
+            parseInt(req.params.userId, 10),
+            isPublic
+        );
+        if (!response) {
+            return res
+                .status(500)
+                .send(resFormat.fail(500, "알수 없는 에러로 정보 얻기 실패"));
+        }
+        return res
+            .status(200)
+            .send(resFormat.successData(200, "정보 얻기 성공", response));
     } catch (err) {
         console.error(err);
         next(err);
@@ -148,15 +208,15 @@ const CreateOption = (id, channelId, postId, bodydata) => {
         },
         createdAt: dbNow(),
     };
-    if(postId){
+    if (postId) {
         Option.post = {
-            connect : {
-            id : parseInt(postId, 10),
-        }}
+            connect: {
+                id: parseInt(postId, 10),
+            },
+        };
     }
     return Option;
 };
-
 
 const CreateObject = (arr) => {
     if (arr === null) return { src: null, createdAt: dbNow() };
@@ -166,7 +226,6 @@ const CreateObject = (arr) => {
     });
     return ArrayChange;
 };
-
 
 const UpdateOption = (bodydata) => {
     // DB에 맞추어 Option 설정

--- a/src/services/CommentServices.js
+++ b/src/services/CommentServices.js
@@ -5,6 +5,7 @@ import { dbNow } from "../utils/dayUtils";
 import bcrypt from "bcrypt";
 
 import resFormat from "../utils/resFormat";
+import { query } from 'express-validator';
 
 export const CreateComment = async (req, res, next) => {
     try {
@@ -44,7 +45,7 @@ export const CreateComment = async (req, res, next) => {
 export const UpdateComment = async (req, res, next) => {
     try {
         const checkAuthor = await CommentRepository.checkMyComment(
-            parseInt(req.params.commentId,10),
+            parseInt(req.params.commentId, 10),
             req.user.id
         );
         if (!checkAuthor[0]) {
@@ -53,7 +54,7 @@ export const UpdateComment = async (req, res, next) => {
                 .send(resFormat.fail(401, "댓글 삭제 권한이 없습니다."));
         }
         const response = await CommentRepository.updateComment(
-            UpdateOption(parseInt(req.params.commentId,10),req.body)
+            UpdateOption(parseInt(req.params.commentId, 10), req.body)
         );
         if (!response) {
             return res
@@ -72,7 +73,7 @@ export const UpdateComment = async (req, res, next) => {
 export const DeleteComment = async (req, res, next) => {
     try {
         const checkAuthor = await CommentRepository.checkMyComment(
-            parseInt(req.params.commentId,10),
+            parseInt(req.params.commentId, 10),
             req.user.id
         );
         if (!checkAuthor[0]) {
@@ -81,7 +82,7 @@ export const DeleteComment = async (req, res, next) => {
                 .send(resFormat.fail(401, "자신의 댓글만 삭제 가능합니다."));
         }
         const response = await CommentRepository.deleteComment(
-            parseInt(req.params.commentId,10)
+            parseInt(req.params.commentId, 10)
         );
         if (!response) {
             return res
@@ -89,6 +90,46 @@ export const DeleteComment = async (req, res, next) => {
                 .send(resFormat.fail(500, "알수 없는 에러로 삭제 실패"));
         }
         return res.status(200).send(resFormat.success(200, "댓글 삭제 성공"));
+    } catch (err) {
+        console.error(err);
+        next(err);
+    }
+};
+
+export const GetComment = async (req, res, next) => {
+    try {
+        const data = await CommentRepository.getCommentById(
+            parseInt(req.params.commentId, 10)
+        );
+        if (!data) {
+            return res
+                .status(500)
+                .send(resFormat.fail(500, "알수 없는 에러로 불러오기 실패"));
+        }
+        return res
+            .status(200)
+            .send(resFormat.successData(200, "댓글 정보 제공", data));
+    } catch (err) {
+        console.error(err);
+        next(err);
+    }
+};
+
+export const GetCommentList = async (req, res, next) => {
+    try {
+        console.log(req.query);
+        const data = await CommentRepository.getCommentByTypeId(
+            String(req.query.type),
+            parseInt(req.query.id, 10)
+        );
+        if (!data) {
+            return res
+                .status(500)
+                .send(resFormat.fail(500, "알수 없는 에러로 불러오기 실패"));
+        }
+        return res
+            .status(200)
+            .send(resFormat.successData(200, "댓글 정보 리스트 제공", data));
     } catch (err) {
         console.error(err);
         next(err);
@@ -114,7 +155,7 @@ const CreateOption = (id, postId, bodydata) => {
     return Option;
 };
 
-const UpdateOption = (id,bodydata) => {
+const UpdateOption = (id, bodydata) => {
     // DB에 맞추어 Option 설정
     const Option = {
         id: parseInt(id, 10),

--- a/src/services/CommentServices.js
+++ b/src/services/CommentServices.js
@@ -5,7 +5,6 @@ import { dbNow } from "../utils/dayUtils";
 import bcrypt from "bcrypt";
 
 import resFormat from "../utils/resFormat";
-import { query } from 'express-validator';
 
 export const CreateComment = async (req, res, next) => {
     try {

--- a/src/services/PostServices.js
+++ b/src/services/PostServices.js
@@ -2,9 +2,6 @@ import * as PostRepository from "../repositories/PostRepository";
 import * as UserRepository from "../repositories/UserRepository";
 import * as AttentionRepository from "../repositories/AttentionRepository";
 import { dbNow } from "../utils/dayUtils";
-
-import bcrypt from "bcrypt";
-
 import resFormat from "../utils/resFormat";
 
 export const CreatePost = async (req, res, next) => {
@@ -50,7 +47,7 @@ export const UpdatePost = async (req, res, next) => {
     try {
         const joinUser = await UserRepository.CheckJoinChannel(
             req.user.id,
-            parseInt(req.body.channelId,10)
+            parseInt(req.body.channelId, 10)
         );
         if (!joinUser[0]) {
             return res
@@ -63,7 +60,7 @@ export const UpdatePost = async (req, res, next) => {
                 );
         }
         const checkAuthor = await PostRepository.checkMyPost(
-            parseInt(req.params.postId,10),
+            parseInt(req.params.postId, 10),
             req.user.id
         );
         if (!checkAuthor[0]) {
@@ -74,7 +71,7 @@ export const UpdatePost = async (req, res, next) => {
                 );
         }
         const response = await PostRepository.updatePost(
-            parseInt(req.params.postId,10),
+            parseInt(req.params.postId, 10),
             UpdateOption(req.body)
         );
         if (!response) {

--- a/src/validations/ArchiveValidation.js
+++ b/src/validations/ArchiveValidation.js
@@ -50,7 +50,6 @@ export const CreateRequestValid = async (req, res, next) => {
     validationFunction(req, res, next);
 };
 
-
 export const DeleteRequestValid = async (req, res, next) => {
     await check("archiveId")
         .notEmpty()
@@ -95,5 +94,35 @@ export const UpdateRequestValid = async (req, res, next) => {
             .withMessage("값이 없습니다.")
             .run(req);
     }
+    validationFunction(req, res, next);
+};
+
+export const GetRequestValid = async (req, res, next) => {
+    await check("archiveId")
+        .notEmpty()
+        .withMessage("값이 없습니다")
+        .isNumeric()
+        .withMessage("archiveId는 숫자 형식이여야 합니다.")
+        .run(req);
+    validationFunction(req, res, next);
+};
+
+export const GetByChannelRequestValid = async (req, res, next) => {
+    await check("channelId")
+        .notEmpty()
+        .withMessage("값이 없습니다")
+        .isNumeric()
+        .withMessage("channelId는 숫자 형식이여야 합니다.")
+        .run(req);
+    validationFunction(req, res, next);
+};
+
+export const GetByUserRequestValid = async (req, res, next) => {
+    await check("userId")
+        .notEmpty()
+        .withMessage("값이 없습니다")
+        .isNumeric()
+        .withMessage("userId는 숫자 형식이여야 합니다.")
+        .run(req);
     validationFunction(req, res, next);
 };

--- a/src/validations/CommentValidation.js
+++ b/src/validations/CommentValidation.js
@@ -47,7 +47,35 @@ export const DeleteRequestValid = async (req, res, next) => {
         .notEmpty()
         .withMessage("값이 없습니다")
         .isNumeric()
-        .withMessage("postId는 숫자 형식이여야 합니다.")
+        .withMessage("commentId는 숫자 형식이여야 합니다.")
+        .run(req);
+    validationFunction(req, res, next);
+};
+
+export const GetRequestValid = async (req, res, next) => {
+    await check("commentId")
+        .notEmpty()
+        .withMessage("값이 없습니다")
+        .isNumeric()
+        .withMessage("commentId는 숫자 형식이여야 합니다.")
+        .run(req);
+    validationFunction(req, res, next);
+};
+
+export const GetListRequestValid = async (req, res, next) => {
+    await check("type")
+        .notEmpty()
+        .withMessage("값이 없습니다")
+        .bail()
+        .isIn(["post", "archive"])
+        .withMessage("값은 post, archive 중에 하나입니다.")
+        .run(req);
+    await check("id")
+        .notEmpty()
+        .withMessage("값이 없습니다")
+        .bail()
+        .isNumeric()
+        .withMessage("id는 숫자 형식이여야 합니다.")
         .run(req);
     validationFunction(req, res, next);
 };


### PR DESCRIPTION
# 개발사항

-   GET /api/Archive/:archiveId
-   GET /api/Archive/channel/:channeId
-   GET /api/Archive/profile/:userId

## 세부사항

###  GET /api/Archive/:archiveId
-   아카이브id로 해당하는 아카이브를 가져옵니다.

###  GET /api/Archive/channel/:channeId

-   해당하는 채널id로 해당 채널의 아카이브 목록을 가져옵니다. 요청을 보낸 유저id가 해당 채널에 속해있는지 검사하여 속해있으면 private, public 모두를 주고 속해있지 않다면 public 게시물만 줍니다.
- 
###  GET /api/Archive/profile/:userId

-   해당하는 유저id로 해당 유저의 아카이브 목록을 가져옵니다. 요청을 보낸 유저id가 해당 유저와 동일한지 검사하여 동일하면(즉, 자신이 자신의 프로필 모아보기를 보는 상황) private, public 모두를 주고 동일하지 않다면 public 게시물만 줍니다.

## 추가사항
https://documenter.getpostman.com/view/17422064/UUy4dkmW#4758c84a-0a18-4543-935d-799616dccbb0
#75 에서 작성된 api도 문서 작성하였음. 내일 포스트맨 공유 워크스페이스 작업시 조율필요합니다.
