### PR TITLE
Fix: GET /api/Archive/:archiveId 응답바디에 archiveLike 추가 (#96)

### DIFF
--- a/src/repositories/ArchiveRepository.js
+++ b/src/repositories/ArchiveRepository.js
@@ -73,6 +73,11 @@ export const getArchiveById = async (id) => {
                         },
                     },
                 },
+                archiveLike: {
+                    select: {
+                        userId: true,
+                    },
+                },
                 tags: {
                     include: {
                         tag: true,


### PR DESCRIPTION
# 개발사항

- GET /api/Archive/:archiveId 응답바디에 archiveLike 추가

## 세부사항

### GET /api/Archive/:archiveId 응답바디에 archiveLike 추가

- 각 아카이브 정보에 공감 상태가 전달되지 않아 전달되게끔 변경.
- 응답 바디는 아래와 같음.
```JSON
{
    "status": 200,
    "success": true,
    "message": "정보 얻기 성공",
    "data": {
        "id": 1,
        "title": "제목 바꿈",
        "status": "Public",
        "content": "hihi",
        "ownerId": 4,
        "channelId": 2,
        "postId": null,
        "createdAt": "2021-10-09T02:51:31.407Z",
        "updatedAt": "2021-10-09T02:52:10.245Z",
        "owner": {
            "id": 4,
            "email": "sjsjsj1246@naver.com",
            "nickname": "sjsjsj1234",
            "profile": {
                "id": 3,
                "department": "asd",
                "introduce": "asd",
                "createdAt": "2021-10-06T20:40:28.832Z",
                "updatedAt": null,
                "userId": 4,
                "profileImage": null
            }
        },
        "post": null,
        "archiveLike": [
            {
                "userId": 4
            }
        ],
        "tags": [],
        "images": []
    }
}
```

## 추가사항
close #96 
