### PR TITLE
Fix: POST /api/Archive/like 레포지토리 함수 부재 픽스 (#98)

### DIFF
--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -595,6 +595,29 @@ export const CheckMyArchive = async (id, archiveId) => {
     }
 };
 
+export const LikeOnArchive = async (userId, archiveId) => {
+    try {
+        return await prisma.user.update({
+            where: {
+                id: userId,
+            },
+            data: {
+                archiveLike: {
+                    create: {
+                        archive: {
+                            connect: {
+                                id: archiveId,
+                            },
+                        },
+                        createdAt: dbNow(),
+                    },
+                },
+            },
+        });
+    } catch (err) {
+        console.error(err);
+    }
+};
 
 export const unLikeOnArchive = async (userId, archiveId) => {
     try {
@@ -615,4 +638,3 @@ export const unLikeOnArchive = async (userId, archiveId) => {
         console.error(err);
     }
 };
-


### PR DESCRIPTION
# 개발사항

-   POST /api/Archive/like 레포지토리 함수 부재 픽스

## 세부사항

### POST /api/Archive/like 레포지토리 함수 부재 픽스

-   #82 에서 실수로 삭제된 UserRepository.LikeOnArchive 함수를 롤백하였습니다.

## 추가사항
fix #98