### PR TITLE
Refactor :  Channel 생성 및 카테고리 리팩토링 (#95)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -238,6 +238,7 @@ model ArchiveTag {
 model Category {
   id        Int              @id @default(autoincrement())
   name      String
+  code      String           @unique
   createdAt DateTime
   updatedAt DateTime?
   channel   ChannelCategory?

--- a/src/services/ChannelServices.js
+++ b/src/services/ChannelServices.js
@@ -342,9 +342,8 @@ const CreateOption = (bodydata) => {
         category: {
             create: {
                 category: {
-                    create: {
-                        name: bodydata.category,
-                        createdAt: dbNow(),
+                    connect: {
+                        code: bodydata.category,
                     },
                 },
                 createdAt: dbNow(),
@@ -374,9 +373,8 @@ const UpdateOption = (bodydata) => {
         Option.category = {
             update: {
                 category: {
-                    update: {
-                        name: bodydata.category,
-                        updatedAt: dbNow(),
+                    connect: {
+                        code: bodydata.category,
                     },
                 },
                 updatedAt: dbNow(),


### PR DESCRIPTION
# 개발사항

-   Category Table 리팩토링 
-   Channel 생성, 수정 로직 변경

## 세부사항

### Category Table 리팩토링 

-   기존의 Category 테이블에 `code`라는 String 변수를 두어 query에 code를 통해 접근하려고 함.
- `code` 는 유일한 data이기 때문에 unique 성질을 추가함.

### Channel 생성 및 업데이트

-   미리 있는 Category data와 생성 혹은 수정하는 Channel 의 data를 연결을 시켜줌.

## 추가사항
- category 테이블의 schema가 변함에 따라 데이터의 손실이 일어남.
-  category code는 규칙을 정해 data로 만들어야 함. 
