### PR TITLE
Refactor : 검색 api 리팩터링 및 기능추가(아카이브 검색) (#93)

### DIFF
--- a/src/controllers/SearchController.js
+++ b/src/controllers/SearchController.js
@@ -5,15 +5,4 @@ const Router = express.Router();
 
 Router.get("/", SearchValidation.SearchoRequestValid, SearchServices.Search);
 
-Router.get(
-    "/channel",
-    SearchValidation.SearchoRequestValid,
-    SearchServices.SearchOnlyChannel
-);
-
-Router.get(
-    "/user",
-    SearchValidation.SearchoRequestValid,
-    SearchServices.SearchOnlyUser
-);
 export default Router;

--- a/src/index.js
+++ b/src/index.js
@@ -69,10 +69,7 @@ app.use(ErrorHandler.logHandler);
 app.use(ErrorHandler.errorHandler);
 
 if (process.env.NODE_ENV === "production") {
-    const buildDirectory = path.resolve(
-        __dirname,
-        "../front_build"
-    );
+    const buildDirectory = path.resolve(__dirname, "../front_build");
     console.log(buildDirectory);
     app.use(express.static(buildDirectory));
     app.use((req, res, next) => {

--- a/src/repositories/ArchiveRepository.js
+++ b/src/repositories/ArchiveRepository.js
@@ -141,6 +141,7 @@ export const getArchiveListByChannelId = async (channelId, isPublic) => {
                         src: true,
                     },
                 },
+                archiveLike: true,
             },
         });
     } catch (err) {
@@ -194,6 +195,72 @@ export const getArchiveListByUserId = async (userId, isPublic) => {
                         src: true,
                     },
                 },
+                archiveLike: true,
+            },
+        });
+    } catch (err) {
+        console.error(err);
+    }
+};
+
+export const findByKeyword = async (keyword, skip, take) => {
+    try {
+        return await prisma.archive.findMany({
+            skip,
+            take,
+            where: {
+                AND: [
+                    {
+                        title: {
+                            contains: keyword,
+                        },
+                    },
+                    {
+                        status: {
+                            equals: "Public",
+                        },
+                    },
+                ],
+            },
+            orderBy: [
+                {
+                    createdAt: "desc",
+                },
+                {
+                    updatedAt: "desc",
+                },
+            ],
+            include: {
+                owner: {
+                    select: {
+                        id: true,
+                        email: true,
+                        nickname: true,
+                        profile: true,
+                    },
+                },
+                post: {
+                    select: {
+                        title: true,
+                        content: true,
+                        createdAt: true,
+                        updatedAt: true,
+                        author: {
+                            select: {
+                                id: true,
+                                email: true,
+                                nickname: true,
+                                profile: true,
+                            },
+                        },
+                    },
+                },
+                images: {
+                    select: {
+                        src: true,
+                    },
+                },
+                archiveLike: true,
             },
         });
     } catch (err) {

--- a/src/repositories/ArchiveRepository.js
+++ b/src/repositories/ArchiveRepository.js
@@ -209,12 +209,25 @@ export const findByKeyword = async (keyword, skip, take) => {
             skip,
             take,
             where: {
-                AND: [
+                OR: [
                     {
                         title: {
                             contains: keyword,
                         },
                     },
+                    {
+                        tags: {
+                            some: {
+                                tag: {
+                                    name: {
+                                        contains: keyword,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                ],
+                AND: [
                     {
                         status: {
                             equals: "Public",
@@ -261,6 +274,11 @@ export const findByKeyword = async (keyword, skip, take) => {
                     },
                 },
                 archiveLike: true,
+                tags: {
+                    include: {
+                        tag: true,
+                    },
+                },
             },
         });
     } catch (err) {

--- a/src/repositories/ChannelRepository.js
+++ b/src/repositories/ChannelRepository.js
@@ -176,11 +176,11 @@ export const findChatLogById = async (id) => {
     }
 };
 
-export const findByKeyword = async (category, keyword, offset = 0) => {
+export const findByKeyword = async (category, keyword, skip, take) => {
     try {
         return await prisma.channel.findMany({
-            skip: offset,
-            take: 6,
+            skip,
+            take,
             where: {
                 OR: [
                     {
@@ -204,14 +204,22 @@ export const findByKeyword = async (category, keyword, offset = 0) => {
                     {
                         category: {
                             category: {
-                                name: {
-                                    contains: category,
+                                code: {
+                                    equals: category,
                                 },
                             },
                         },
                     },
                 ],
             },
+            orderBy: [
+                {
+                    createdAt: "desc",
+                },
+                {
+                    updatedAt: "desc",
+                },
+            ],
             include: {
                 admin: {
                     select: {
@@ -245,7 +253,6 @@ export const findByKeyword = async (category, keyword, offset = 0) => {
                         tag: true,
                     },
                 },
-                channelImage: true,
             },
         });
     } catch (err) {

--- a/src/repositories/ChannelRepository.js
+++ b/src/repositories/ChannelRepository.js
@@ -205,7 +205,7 @@ export const findByKeyword = async (category, keyword, skip, take) => {
                         category: {
                             category: {
                                 code: {
-                                    equals: category,
+                                    in: category,
                                 },
                             },
                         },

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -453,11 +453,11 @@ export const NotAttention = async (userId, postId) => {
     }
 };
 
-export const findByKeyword = async (keyword, offset = 0) => {
+export const findByKeyword = async (keyword, skip, take) => {
     try {
         return await prisma.user.findMany({
-            skip: offset,
-            take: 6,
+            skip,
+            take,
             where: {
                 OR: [
                     {
@@ -489,6 +489,14 @@ export const findByKeyword = async (keyword, offset = 0) => {
                     },
                 ],
             },
+            orderBy: [
+                {
+                    createdAt: "desc",
+                },
+                {
+                    updatedAt: "desc",
+                },
+            ],
             select: {
                 id: true,
                 email: true,

--- a/src/services/SearchServices.js
+++ b/src/services/SearchServices.js
@@ -1,88 +1,70 @@
 import * as ChannelRepository from "../repositories/ChannelRepository";
 import * as UserRepository from "../repositories/UserRepository";
+import * as ArchiveRepository from "../repositories/ArchiveRepository";
 import resFormat from "../utils/resFormat";
 
 export const Search = async (req, res, next) => {
     try {
-        const skipChannel = isNaN(req.query.skipChannel)
-            ? 0
-            : parseInt(req.query.skipChannel, 10);
-        const skipUser = isNaN(req.query.skipUser)
-            ? 0
-            : parseInt(req.query.skipUser, 10);
-        const channelData = await ChannelRepository.findByKeyword(
-            req.query.category,
-            req.query.keyword,
-            skipChannel
-        );
-        if (!channelData) {
+        const type = req.query.type ? req.query.type : "channel";
+        const keyword = req.query.keyword;
+        const skip = req.query.skip ? parseInt(req.query.skip, 10) : 0;
+        const take = req.query.take ? parseInt(req.query.take, 10) : 12;
+        const code = req.query.code ? req.query.code : undefined;
+        if (type == "channel") {
+            const response = await ChannelRepository.findByKeyword(
+                code,
+                keyword,
+                skip,
+                take
+            );
+            if (!response) {
+                return res
+                    .status(500)
+                    .send(
+                        resFormat.fail(500, "알수 없는 에러로 채널 검색 실패")
+                    );
+            }
             return res
-                .status(500)
-                .send(resFormat.fail(500, "알수 없는 에러로 검색 실패"));
-        }
-        const userData = await UserRepository.findByKeyword(
-            req.query.keyword,
-            skipUser
-        );
-        if (!userData) {
+                .status(200)
+                .send(resFormat.successData(200, "채널 검색 성공", response));
+        } else if (type == "user") {
+            const response = await UserRepository.findByKeyword(
+                keyword,
+                skip,
+                take
+            );
+            if (!response) {
+                return res
+                    .status(500)
+                    .send(
+                        resFormat.fail(500, "알수 없는 에러로 유저 검색 실패")
+                    );
+            }
             return res
-                .status(500)
-                .send(resFormat.fail(500, "알수 없는 에러로 검색 실패"));
-        }
-        const data = {
-            channel: channelData,
-            user: userData,
-        };
-        return res
-            .status(200)
-            .send(resFormat.successData(200, "검색 성공", data));
-    } catch (err) {
-        console.error(err);
-        next(err);
-    }
-};
-
-export const SearchOnlyChannel = async (req, res, next) => {
-    try {
-        const skipChannel = isNaN(req.query.skipChannel)
-            ? 0
-            : parseInt(req.query.skipChannel, 10);
-        const channelData = await ChannelRepository.findByKeyword(
-            req.query.category,
-            req.query.keyword,
-            skipChannel
-        );
-        if (!channelData) {
+                .status(200)
+                .send(resFormat.successData(200, "유저 검색 성공", response));
+        } else if (type == "archive") {
+            const response = await ArchiveRepository.findByKeyword(
+                keyword,
+                skip,
+                take
+            );
+            if (!response) {
+                return res
+                    .status(500)
+                    .send(
+                        resFormat.fail(
+                            500,
+                            "알수 없는 에러로 모아보기 검색 실패"
+                        )
+                    );
+            }
             return res
-                .status(500)
-                .send(resFormat.fail(500, "알수 없는 에러로 검색 실패"));
+                .status(200)
+                .send(
+                    resFormat.successData(200, "모아보기 검색 성공", response)
+                );
         }
-        return res
-            .status(200)
-            .send(resFormat.successData(200, "검색 성공", channelData));
-    } catch (err) {
-        console.error(err);
-        next(err);
-    }
-};
-
-export const SearchOnlyUser = async (req, res, next) => {
-    try {
-        const skipUser = isNaN(req.query.skipUser)
-            ? 0
-            : parseInt(req.query.skipUser, 10);
-        const userData = await UserRepository.findByKeyword(
-            req.query.keyword,
-            skipUser
-        );
-        if (!userData) {
-            return res
-                .status(500)
-                .send(resFormat.fail(500, "알수 없는 에러로 검색 실패"));
-        }
-        return res
-            .status(200)
-            .send(resFormat.successData(200, "검색 성공", userData));
     } catch (err) {
         console.error(err);
         next(err);

--- a/src/services/SearchServices.js
+++ b/src/services/SearchServices.js
@@ -9,7 +9,7 @@ export const Search = async (req, res, next) => {
         const keyword = req.query.keyword;
         const skip = req.query.skip ? parseInt(req.query.skip, 10) : 0;
         const take = req.query.take ? parseInt(req.query.take, 10) : 12;
-        const code = req.query.code ? req.query.code : undefined;
+        const code = req.query.code ? req.query.code.split("!") : undefined;
         if (type == "channel") {
             const response = await ChannelRepository.findByKeyword(
                 code,

--- a/src/services/SearchServices.js
+++ b/src/services/SearchServices.js
@@ -6,7 +6,7 @@ import resFormat from "../utils/resFormat";
 export const Search = async (req, res, next) => {
     try {
         const type = req.query.type ? req.query.type : "channel";
-        const keyword = req.query.keyword;
+        const keyword = req.query.keyword ? req.query.keyword : undefined;
         const skip = req.query.skip ? parseInt(req.query.skip, 10) : 0;
         const take = req.query.take ? parseInt(req.query.take, 10) : 12;
         const code = req.query.code ? req.query.code.split("!") : undefined;

--- a/src/validations/SearchValidation.js
+++ b/src/validations/SearchValidation.js
@@ -9,7 +9,32 @@ export const SearchoRequestValid = async (req, res, next) => {
         .run(req);
     await query("code")
         .if(query("code").exists())
-        .isString()
+        .isIn([
+            "ART",
+            "COOK",
+            "INVEST",
+            "LANGUAGE",
+            "DESIGN",
+            "BEAUTY",
+            "PROGRAMMING",
+            "STARTUP",
+            "MUSIC",
+            "INTERIOR",
+            "EXAM",
+            "SPORTS",
+            "ACT",
+            "PET",
+            "CAREER",
+            "HEALTH",
+            "DANCE",
+            "TRAVEL",
+            "STUDY",
+            "RELATIONSHIP",
+            "LIFE",
+            "MEDIA",
+            "HOBBY",
+            "ETC",
+        ])
         .withMessage("정해진 카테고리 code 형식에 맞아야 합니다.")
         .run(req);
     await query("keyword")

--- a/src/validations/SearchValidation.js
+++ b/src/validations/SearchValidation.js
@@ -2,25 +2,30 @@ import { query } from "express-validator";
 import validationFunction from "./validationFunction";
 
 export const SearchoRequestValid = async (req, res, next) => {
-    await query("category")
-        .if(query("category").exists())
+    await query("type")
+        .if(query("type").exists())
+        .isIn(["channel", "user", "archive"])
+        .withMessage("type값은 channel, user, archive 중에 하나입니다.")
+        .run(req);
+    await query("code")
+        .if(query("code").exists())
         .isString()
-        .withMessage("category 문자열이어야 합니다.")
+        .withMessage("정해진 카테고리 code 형식에 맞아야 합니다.")
         .run(req);
     await query("keyword")
         .if(query("keyword").exists())
         .isString()
         .withMessage("keyword는 문자열이어야 합니다.")
         .run(req);
-    await query("skipChannel")
-        .if(query("skipChannel").exists())
+    await query("skip")
+        .if(query("skip").exists())
         .isNumeric()
-        .withMessage("skipChannel은 숫자이어야합니다.")
+        .withMessage("skip은 숫자이어야합니다.")
         .run(req);
-    await query("skipUser")
-        .if(query("skipUser").exists())
+    await query("take")
+        .if(query("take").exists())
         .isNumeric()
-        .withMessage("skipUser은 숫자이어야합니다.")
+        .withMessage("take은 숫자이어야합니다.")
         .run(req);
     validationFunction(req, res, next);
 };

--- a/src/validations/SearchValidation.js
+++ b/src/validations/SearchValidation.js
@@ -9,32 +9,40 @@ export const SearchoRequestValid = async (req, res, next) => {
         .run(req);
     await query("code")
         .if(query("code").exists())
-        .isIn([
-            "ART",
-            "COOK",
-            "INVEST",
-            "LANGUAGE",
-            "DESIGN",
-            "BEAUTY",
-            "PROGRAMMING",
-            "STARTUP",
-            "MUSIC",
-            "INTERIOR",
-            "EXAM",
-            "SPORTS",
-            "ACT",
-            "PET",
-            "CAREER",
-            "HEALTH",
-            "DANCE",
-            "TRAVEL",
-            "STUDY",
-            "RELATIONSHIP",
-            "LIFE",
-            "MEDIA",
-            "HOBBY",
-            "ETC",
-        ])
+        .custom((value, { req }) => {
+            const arr = value.split("!");
+            const Dictionary = [
+                "ART",
+                "COOK",
+                "INVEST",
+                "LANGUAGE",
+                "DESIGN",
+                "BEAUTY",
+                "PROGRAMMING",
+                "STARTUP",
+                "MUSIC",
+                "INTERIOR",
+                "EXAM",
+                "SPORTS",
+                "ACT",
+                "PET",
+                "CAREER",
+                "HEALTH",
+                "DANCE",
+                "TRAVEL",
+                "STUDY",
+                "RELATIONSHIP",
+                "LIFE",
+                "MEDIA",
+                "HOBBY",
+                "ETC",
+            ];
+            for (let i in arr) {
+                console.log(arr[i]);
+                if (Dictionary.indexOf(arr[i]) == -1) return false;
+            }
+            return true;
+        })
         .withMessage("정해진 카테고리 code 형식에 맞아야 합니다.")
         .run(req);
     await query("keyword")

--- a/src/validations/SearchValidation.js
+++ b/src/validations/SearchValidation.js
@@ -38,7 +38,6 @@ export const SearchoRequestValid = async (req, res, next) => {
                 "ETC",
             ];
             for (let i in arr) {
-                console.log(arr[i]);
                 if (Dictionary.indexOf(arr[i]) == -1) return false;
             }
             return true;


### PR DESCRIPTION
# 개발사항

-   검색 api 리팩토링
-   아카이브(모아보기 검색추가)

## 세부사항

### 검색 api

-  기존 검색 api는 전체, 채널, 유저 세가지로 나누어져 있었습니다. 좀 더 효율적으로 만들기 위해 하나의 api로 가능하게 리팩토링을 수행했습니다.

### `GET : /api/Search/?type=&code=&keyword=&skip=&take=`

|query|설명|
|----|----|
|type|channel, user, archive 중에서  사용 가능 (default: channel)|
|code|type이 channel 값을 가지는 경우, code를 통해 특정 카테고리에서만 검색 가능|
|keyword|keyword가 들어가는 data filtering|
|skip|skip하는 개수 (default:0)|
|take|가져오는 data 개수 (default:12)|

code의 경우, 카테고리가 다중 선택이 가능하므로 구별을 위해 !를 code앞에 붙여 구별을 해줌

예시 
>/api/Search/?type=channel&code=PROGRAMMING!COOK&keyword=키워드&skip=3&take=6

### 아카이브(모아보기) 검색 기능 추가

### `GET : /api/Search/?type="archive"&code=""&keyword=""&skip=""&take=""`
- type 에 archive 값을 줄 경우, 아카이브 내용만 가져옴
- status가 `Public` 인 아카이브만 검색 가능하게 함.

## 추가사항
- 정렬 순서는 시간 순입니다. 추후, 좋아요의 개수에 따른 순서가 있는 경우 기능 추가 예정