### PR TITLE
feat: 답장쌍 조회 로직 변경 (#102)

### DIFF
--- a/src/repositories/ChatMessageRepository.js
+++ b/src/repositories/ChatMessageRepository.js
@@ -216,11 +216,14 @@ export const createRoomChatAnswer = async (
     }
 };
 
-export const findRoomAnswerChat = async (channelRoomId) => {
+export const findRoomAnswerChat = async (sendUserId, channelRoomId) => {
     try {
         let data = await prisma.chatMessage.findMany({
             where: {
                 AND: [
+                    {
+                        sendUserId,
+                    },
                     {
                         channelRoomId,
                     },

--- a/src/services/ChatServices.js
+++ b/src/services/ChatServices.js
@@ -27,8 +27,10 @@ export const GetMainChatLog = async (req, res, next) => {
             lastId,
             parseInt(req.query.limit, 10)
         );
-        if (!response) {
-            return res.status(400).send(resFormat.fail(400, "실패"));
+        if (!response[0]) {
+            return res
+                .status(200)
+                .send(resFormat.successData(200, "채널 채팅이 없습니다.", []));
         }
         return res
             .status(200)
@@ -100,7 +102,9 @@ export const GetRoomChatLog = async (req, res, next) => {
             parseInt(req.query.limit, 10)
         );
         if (!response[0]) {
-            return res.status(400).send(resFormat.fail(400, "실패"));
+            return res
+                .status(200)
+                .send(resFormat.successData(200, "채팅방 채팅이 없습니다", []));
         }
         return res
             .status(200)
@@ -161,6 +165,7 @@ export const RoomChatAnswer = async (req, res, next) => {
 export const GetRoomChatAnswerList = async (req, res, next) => {
     try {
         const findAnswer = await ChatMessageRepository.findRoomAnswerChat(
+            req.user.id,
             parseInt(req.params.roomId)
         );
         if (!findAnswer[0]) {


### PR DESCRIPTION
# 개발사항

-   답장쌍 로직 중, 로그인한 유저의 id 조건까지 추가
-   채팅방 채팅 조회, 잡담방 채팅 조회시 값이 없으면 빈 배열 리턴

## 세부사항

### 답장쌍 로직 중, 로그인한 유저의 id 조건까지 추가

-   지난 기획 회의에서 모든 답장쌍이 아닌, 방장의 답장쌍이기 때문에, 로그인한 유저로 조건을 넣어서 추가했습니다.

### 채팅방 채팅 조회, 잡담방 채팅 조회시 값이 없으면 빈 배열 리턴

-   빈 배열 리턴 hotfix,

## 추가사항
