### PR TITLE
Fix: 검색 api 버그 수정 및 페이지네이션 버그 수정

### DIFF
--- a/src/repositories/ArchiveRepository.js
+++ b/src/repositories/ArchiveRepository.js
@@ -205,36 +205,37 @@ export const getArchiveListByUserId = async (userId, isPublic) => {
 
 export const findByKeyword = async (keyword, skip, take) => {
     try {
-        return await prisma.archive.findMany({
-            skip,
-            take,
-            where: {
-                OR: [
-                    {
-                        title: {
-                            contains: keyword,
-                        },
+        const whereQuery = {
+            OR: [
+                {
+                    title: {
+                        contains: keyword,
                     },
-                    {
-                        tags: {
-                            some: {
-                                tag: {
-                                    name: {
-                                        contains: keyword,
-                                    },
+                },
+                {
+                    tags: {
+                        some: {
+                            tag: {
+                                name: {
+                                    contains: keyword,
                                 },
                             },
                         },
                     },
-                ],
-                AND: [
-                    {
-                        status: {
-                            equals: "Public",
-                        },
+                },
+            ],
+            AND: [
+                {
+                    status: {
+                        equals: "Public",
                     },
-                ],
-            },
+                },
+            ],
+        };
+        const query = {
+            skip,
+            take,
+            where: whereQuery,
             orderBy: [
                 {
                     createdAt: "desc",
@@ -280,7 +281,15 @@ export const findByKeyword = async (keyword, skip, take) => {
                     },
                 },
             },
+        };
+        const archives = prisma.archive.findMany(query);
+        const totalCount = prisma.archive.count({
+            where: whereQuery,
         });
+        return {
+            archives,
+            totalCount,
+        };
     } catch (err) {
         console.error(err);
     }

--- a/src/repositories/ArchiveRepository.js
+++ b/src/repositories/ArchiveRepository.js
@@ -153,12 +153,11 @@ export const getArchiveListByChannelId = async (
             },
         };
         const archives = await prisma.archive.findMany(query);
-        const totalPage =
-            parseInt(
-                (await prisma.archive.count({
-                    where: whereQuery,
-                })) / pageSize
-            ) + 1;
+        const totalPage = Math.ceil(
+            (await prisma.archive.count({
+                where: whereQuery,
+            })) / pageSize
+        );
         return {
             archives,
             totalPage,

--- a/src/repositories/ArchiveRepository.js
+++ b/src/repositories/ArchiveRepository.js
@@ -301,8 +301,8 @@ export const findByKeyword = async (keyword, skip, take) => {
                 },
             },
         };
-        const archives = prisma.archive.findMany(query);
-        const totalCount = prisma.archive.count({
+        const archives = await prisma.archive.findMany(query);
+        const totalCount = await prisma.archive.count({
             where: whereQuery,
         });
         return {

--- a/src/repositories/ChannelRepository.js
+++ b/src/repositories/ChannelRepository.js
@@ -254,6 +254,11 @@ export const findByKeyword = async (category, keyword, skip, take) => {
                         tag: true,
                     },
                 },
+                participants: {
+                    select: {
+                        userId: true,
+                    },
+                },
             },
         };
         const channels = await prisma.channel.findMany(query);

--- a/src/repositories/ChannelRepository.js
+++ b/src/repositories/ChannelRepository.js
@@ -178,40 +178,41 @@ export const findChatLogById = async (id) => {
 
 export const findByKeyword = async (category, keyword, skip, take) => {
     try {
-        return await prisma.channel.findMany({
+        const whereQuery = {
+            OR: [
+                {
+                    name: {
+                        contains: keyword,
+                    },
+                },
+                {
+                    tags: {
+                        some: {
+                            tag: {
+                                name: {
+                                    contains: keyword,
+                                },
+                            },
+                        },
+                    },
+                },
+            ],
+            AND: [
+                {
+                    category: {
+                        category: {
+                            code: {
+                                in: category,
+                            },
+                        },
+                    },
+                },
+            ],
+        };
+        const query = {
             skip,
             take,
-            where: {
-                OR: [
-                    {
-                        name: {
-                            contains: keyword,
-                        },
-                    },
-                    {
-                        tags: {
-                            some: {
-                                tag: {
-                                    name: {
-                                        contains: keyword,
-                                    },
-                                },
-                            },
-                        },
-                    },
-                ],
-                AND: [
-                    {
-                        category: {
-                            category: {
-                                code: {
-                                    in: category,
-                                },
-                            },
-                        },
-                    },
-                ],
-            },
+            where: whereQuery,
             orderBy: [
                 {
                     createdAt: "desc",
@@ -254,7 +255,15 @@ export const findByKeyword = async (category, keyword, skip, take) => {
                     },
                 },
             },
+        };
+        const channels = await prisma.channel.findMany(query);
+        const totalCount = await prisma.channel.count({
+            where: whereQuery,
         });
+        return {
+            channels,
+            totalCount,
+        };
     } catch (err) {
         console.error(err);
     }

--- a/src/repositories/PostRepository.js
+++ b/src/repositories/PostRepository.js
@@ -134,17 +134,15 @@ export const findPostByChannelId = async (channelId, type, page, pageSize) => {
         query.take = pageSize;
         ret = ret.concat(await prisma.post.findMany(query));
 
-        const totalPage =
-            parseInt(
-                (await prisma.post.count({
-                    where: whereQuery,
-                })) / pageSize
-            ) + 1;
-        const data = {
+        const totalPage = Math.ceil(
+            (await prisma.post.count({
+                where: whereQuery,
+            })) / pageSize
+        );
+        return {
             posts: ret,
             totalPage,
         };
-        return data;
     } catch (err) {
         console.error(err);
     }

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -456,7 +456,7 @@ export const NotAttention = async (userId, postId) => {
 
 export const findByKeyword = async (keyword, skip, take) => {
     try {
-        const whereQuery = {
+        let whereQuery = {
             OR: [
                 {
                     nickname: {
@@ -487,6 +487,7 @@ export const findByKeyword = async (keyword, skip, take) => {
                 },
             ],
         };
+        if (!keyword) whereQuery = undefined;
         const query = {
             skip,
             take,

--- a/src/services/ArchiveServices.js
+++ b/src/services/ArchiveServices.js
@@ -163,7 +163,9 @@ export const GetChannelArchiveList = async (req, res, next) => {
         }
         const response = await ArchiveRepository.getArchiveListByChannelId(
             parseInt(req.params.channelId, 10),
-            isPublic
+            isPublic,
+            parseInt(req.query.page, 10),
+            parseInt(req.query.pageSize, 10)
         );
         if (!response) {
             return res

--- a/src/validations/ArchiveValidation.js
+++ b/src/validations/ArchiveValidation.js
@@ -121,6 +121,18 @@ export const GetByChannelRequestValid = async (req, res, next) => {
         .isNumeric()
         .withMessage("channelId는 숫자 형식이여야 합니다.")
         .run(req);
+    await check("page")
+        .notEmpty()
+        .withMessage("값이 없습니다")
+        .isNumeric()
+        .withMessage("page는 숫자 형식이여야 합니다.")
+        .run(req);
+    await check("pageSize")
+        .notEmpty()
+        .withMessage("값이 없습니다")
+        .isNumeric()
+        .withMessage("pageSize는 숫자 형식이여야 합니다.")
+        .run(req);
     validationFunction(req, res, next);
 };
 

--- a/src/validations/SearchValidation.js
+++ b/src/validations/SearchValidation.js
@@ -37,6 +37,7 @@ export const SearchoRequestValid = async (req, res, next) => {
                 "HOBBY",
                 "ETC",
             ];
+            if (!arr[0]) return true;
             for (let i in arr) {
                 if (Dictionary.indexOf(arr[i]) == -1) return false;
             }


### PR DESCRIPTION
# 개발사항


- fix #115 
- fix #117 
- fix #118 
- fix #119 
- fix #120 
- fix #121 

## 세부사항

### #115 
-  channel, user, archive 모두 전체 갯수를 세서 응답바디에 보내주도록 변경

### #117 
- 페이지네이션 추가


### #118 
-  쿼리문에 아래를 추가했습니다.
```JS
participants: {
    select: {
            userId: true,
        },
    },
```

### #119
- `Math.ceil()`을 사용하도록 변경


### #120
- user일때는 where 쿼리가 모두 keyword에 관계가 맺어있어서 keyword가 null 일경우 관계된 profile에 wellTalent, interestTalent가 있는 사람만 검사함. 따라서 관심재능이나 잘하는 재능을 등록한 사람만 검색결과에 나타났는데, 이에 관계없이 모두 나타나도록 keyword가 null이면 where을 undefined로 해주었음.


### #121 
- validation에서 arr이 아무것도 없는 배열이거나 배열이 아닐경우 통과하도록 함.

## 추가사항

api 문서 업데이트 했습니다.
https://documenter.getpostman.com/view/14901542/Tzz7Pdio#c419310e-3512-4030-a2c4-deb178ec115a