### PR TITLE
fix: mychannel api getOwnerRoom 픽스 (#141)

### DIFF
--- a/src/repositories/ChannelRoomRepository.js
+++ b/src/repositories/ChannelRoomRepository.js
@@ -149,7 +149,16 @@ export const findOwnerRoom = async (userId) => {
     try {
         let data = await prisma.channelRoom.findMany({
             where: {
-                userId,
+                AND: [
+                    {
+                        userId,
+                    },
+                    {
+                        status: {
+                            not: "Archived",
+                        },
+                    },
+                ],
             },
             orderBy: {
                 status: "asc",


### PR DESCRIPTION
# 개발사항

-   mychannel api에서 OwnerRoom을 받아올 때 Archived 상태의
   채팅방은 가져오지 않게 수정하였음


## 추가사항
